### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/firebase_functions_v2/out-of-town-notifications.js
+++ b/firebase_functions_v2/out-of-town-notifications.js
@@ -64,7 +64,7 @@ exports.sendOutOfTownEventNotificationV2 = onDocumentWritten({
     let apiKeyValue = brevoApiKey.value().trim();
     // Remove any newline characters
     apiKeyValue = apiKeyValue.replace(/[\r\n]+/g, '');
-    console.log('Using Brevo API key:', apiKeyValue.substring(0, 5) + '...');
+    console.log('Using Brevo API key for transactional emails');
     apiKey.apiKey = apiKeyValue;
 
     const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/11](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/11)

To fix the problem, remove any logging of the API key altogether. Do not log the API key, not even a substring or masked version, since any portion of a secret may compromise its security or violate compliance controls. Instead, log a static message indicating that the API key is being used, without printing any segment of the key. Edit file `firebase_functions_v2/out-of-town-notifications.js`, replacing line 67 with a generic message, such as `console.log('Using Brevo API key for transactional emails');`. No new imports or method additions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
