### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/firebase_functions_v2/out-of-town-emails.js
+++ b/firebase_functions_v2/out-of-town-emails.js
@@ -63,7 +63,7 @@ exports.sendOutOfTownGuestEmailV2 = onDocumentWritten({
     let apiKeyValue = brevoApiKey.value().trim();
     // Remove any newline characters
     apiKeyValue = apiKeyValue.replace(/[\r\n]+/g, '');
-    console.log('Using Brevo API key:', apiKeyValue.substring(0, 5) + '...');
+    console.log('Using Brevo API key for transactional emails');
     apiKey.apiKey = apiKeyValue;
 
     const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/10](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/10)

To remediate the issue, the code should be modified so that no part of the Brevo API key is logged to the console at any point. The debugging information can be preserved by logging a generic message confirming the presence and type of the secret (e.g., "Using Brevo API key for transactional emails"), but never logging any part or value of the key itself. Specifically, in `firebase_functions_v2/out-of-town-emails.js`, line 66 should be changed so that it does not reveal any character of the API key, but instead logs an acceptable, non-sensitive message for developers. No new imports or custom logic are needed beyond this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
