### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/firebase_functions_v2/enhanced-email-functions.js
+++ b/firebase_functions_v2/enhanced-email-functions.js
@@ -165,7 +165,7 @@ exports.sendStyledRsvpUpdateConfirmationV2 = onDocumentUpdated({
     let apiKeyValue = brevoApiKey.value().trim();
     // Remove any newline characters
     apiKeyValue = apiKeyValue.replace(/[\r\n]+/g, '');
-    console.log('Using Brevo API key:', apiKeyValue.substring(0, 5) + '...');
+    console.log('Brevo API key loaded successfully.');
     apiKey.apiKey = apiKeyValue;
 
     const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/9](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/9)

To fix the problem, the log statement revealing even a portion of the secret value (`apiKeyValue.substring(0, 5)`) should be removed or replaced. Instead, if debugging is needed, logging can use a static message such as "Brevo API key loaded successfully" without showing any portion of the key. This change should only affect line 168 in the file `firebase_functions_v2/enhanced-email-functions.js`. No imports or additional libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
