### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/enhanced-email-deliverability-test.js
+++ b/enhanced-email-deliverability-test.js
@@ -21,6 +21,20 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 
+
+// Helper to check if CNAME belongs to trusted providers
+function isTrustedCname(cname) {
+  // Normalize case
+  const domain = cname.trim().toLowerCase().replace(/\.$/, '');
+  const allowed = [
+    'sendinblue.com',
+    'brevo.com'
+  ];
+  return allowed.some(allowedDomain => 
+    domain === allowedDomain || domain.endsWith('.' + allowedDomain)
+  );
+}
+
 // Promisify DNS methods
 const resolveTxt = promisify(dns.resolveTxt);
 const resolveMx = promisify(dns.resolveMx);
@@ -190,7 +204,7 @@ async function checkReturnPath() {
         console.log(chalk.green('✅ Return-Path configuration found (CNAME):'));
         console.log(chalk.gray(`  ${records[0]}`));
         
-        if (records[0].includes('sendinblue.com') || records[0].includes('brevo.com')) {
+        if (isTrustedCname(records[0])) {
           console.log(chalk.green('✅ Properly configured with Brevo/Sendinblue'));
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/7](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/7)

To fix the issue, we must correctly validate that the CNAME value is either exactly `brevo.com`/`sendinblue.com` or is a subdomain of these. This can be achieved by parsing the CNAME string and checking if it matches an explicit allowed domain or ends with `.brevo.com` or `.sendinblue.com` (without being part of a longer TLD, i.e., not `brevo.com.evil.com`). The code to do this should replace the `.includes()` matches with a function that safely checks if the CNAME is exactly the trusted domain or a direct/indirect subdomain (ending with `.<trusted-domain>`).

All that is needed is a small helper function to perform this check, plus updating the conditionals in the relevant location(s) in `enhanced-email-deliverability-test.js`, around line 193.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
