### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL scheme check

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -163,7 +163,13 @@ function trackElementClicks(selector, eventName, eventType = 'click') {
             } else {
                 // For normal clicks, we can delay a bit to ensure the event is sent
                 const href = element.getAttribute('href');
-                if (href && href.indexOf('#') !== 0 && href.indexOf('javascript:') !== 0) {
+                if (
+                    href &&
+                    href.indexOf('#') !== 0 &&
+                    href.indexOf('javascript:') !== 0 &&
+                    href.indexOf('data:') !== 0 &&
+                    href.indexOf('vbscript:') !== 0
+                ) {
                     // It's a link that navigates away
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/3](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/3)

To fix the issue, the check on line 166 for links should be extended to also reject URLs beginning with "data:" and "vbscript:" (case-insensitive and after trimming whitespace, ideally). Since the fix needs to change only the shown snippet and minimal functionality, we can simply extend the existing check by using a regular expression or additional `indexOf` comparisons that treat all three schemes equally. For best compatibility and minimal change, add `href.indexOf('data:') !== 0` and `href.indexOf('vbscript:') !== 0` to the conditional, so any link starting with any of these schemes is treated as "not navigable".

No additional imports or dependencies are required as we are working with basic string checks in JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
