### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/firebase_functions_v2/enhanced-email-functions.js
+++ b/firebase_functions_v2/enhanced-email-functions.js
@@ -40,7 +40,8 @@ exports.sendStyledRsvpConfirmationV2 = onDocumentCreated({
     let apiKeyValue = brevoApiKey.value().trim();
     // Remove any newline characters
     apiKeyValue = apiKeyValue.replace(/[\r\n]+/g, '');
-    console.log('Using Brevo API key:', apiKeyValue.substring(0, 5) + '...');
+    // Do NOT log the API key itself or any part of it for security reasons
+    console.log('Brevo API key is set and non-empty: ', !!apiKeyValue);
     apiKey.apiKey = apiKeyValue;
 
     const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/8](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/8)

To remediate the issue, remove the logging of any portion of the API key from the logs. Do not log the API key at all, even its substring or masked version. If logging is required for debugging purposes, only log whether the key is present (for example, whether it is non-empty), but never its value or any substring. Specifically, remove or replace line 43 in the file `firebase_functions_v2/enhanced-email-functions.js`. No new imports or methods are needed, just replace or remove the problematic logging statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
