### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,3 +1,4 @@
+permissions: {}
 name: Cloudflare Pages Deployment
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/1](https://github.com/JSB2010/Eli-Barkin-Be-Mitzvah-Website/security/code-scanning/1)

To address the problem, we should add a `permissions` block to the workflow to explicitly set the least privileges required by the job. Since the job neither reads nor writes repository contents, and does not interact with issues, pull requests, or any other privileged resources, we can lock down the permissions entirely by setting all permissions to `none`. The recommended method, per GitHub documentation, is to add `permissions: none` at the workflow root, which applies to all jobs, or under the job itself if only that job is affected. In this case, adding the following at the root level (after the workflow `name` and before `on:`) is appropriate:

```yaml
permissions: {}
```

(Or, equivalently, `permissions: none` for YAML workflows that require all permissions to be disabled.)

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
